### PR TITLE
new: stickied social media share links

### DIFF
--- a/src/components/home/Home.jsx
+++ b/src/components/home/Home.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import i18next from "i18next";
 import HomePage from "./HomePage";
+import ShareLinks from "../share-links/ShareLinks";
 import Visualization from "../visualization/Visualization";
 import Heatmap from "../heatmap/Heatmap";
 import TrackYourSymptoms from "../form/TrackYourSymptoms";
@@ -18,6 +19,7 @@ const Home = () => {
       {somaliToggle && <Heatmap />}
       {somaliToggle && <EsriLink />}
       <Info />
+      <ShareLinks />
     </React.Fragment>
   );
 };

--- a/src/components/share-links/ShareLinks.jsx
+++ b/src/components/share-links/ShareLinks.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import {
+  FacebookShareButton,
+  FacebookIcon,
+  RedditShareButton,
+  RedditIcon,
+  TwitterShareButton,
+  TwitterIcon,
+} from "react-share";
+
+const url = "www.flatten.ca";
+const title =
+  "I helped flatten the curve of COVID-19 by filling out a form for an interactive heatmap, check it out here: www.flatten.ca";
+const ShareLinks = () => {
+  return (
+    <div className="share-links-container">
+      <FacebookShareButton
+        className="sticky-share-buttons"
+        url={url}
+        quote={title}
+      >
+        <FacebookIcon size={32} round={true} />
+      </FacebookShareButton>
+      <TwitterShareButton
+        className="sticky-share-buttons"
+        url={url}
+        title={title}
+      >
+        <TwitterIcon size={32} round={true} />
+      </TwitterShareButton>
+      <RedditShareButton
+        className="sticky-share-buttons"
+        url={url}
+        title={title}
+      >
+        <RedditIcon size={32} round={true} />
+      </RedditShareButton>
+    </div>
+  );
+};
+export default ShareLinks;

--- a/src/styles/import.scss
+++ b/src/styles/import.scss
@@ -26,3 +26,4 @@
 @import "./footer/footer.scss";
 @import "./legal/legal.scss";
 @import "./notfound/notfoundpage.scss";
+@import "./share-links/shareLinks.scss";

--- a/src/styles/share-links/shareLinks.scss
+++ b/src/styles/share-links/shareLinks.scss
@@ -1,0 +1,27 @@
+.share-links-container {
+  display: block;
+  width: 32px;
+  position: sticky;
+  bottom: 20px;
+  left: 20px;
+}
+.sticky-share-buttons {
+  height: 42px;
+}
+
+@media only screen and (max-width: 1000px) {
+  .sticky-share-buttons {
+    width: 100%;
+    height: 20px;
+  }
+  .share-links-container {
+    bottom: 10px;
+    left: 10px;
+  }
+}
+
+@media only screen and (max-width: 500px) {
+  .share-links-container {
+    position: absolute;
+  }
+}


### PR DESCRIPTION
- New ShareLinks component that is stickied to the bottom left of the page
- Below 500px, the component only exists on the splash page, to reduce mobile annoyance 